### PR TITLE
add blank KiCad project for IMU hardware

### DIFF
--- a/imu-module/imu-module.pro
+++ b/imu-module/imu-module.pro
@@ -1,0 +1,4 @@
+update=Wed 28 Oct 2015 17:32:17 GMT
+last_client=kicad
+[general]
+version=1


### PR DESCRIPTION
If we're to use this repo for the IMU hardware development then here is a blank
Kicad project. If not, then we can trivially create cuspaceflight/imu-module or
similar.
