### PR TITLE
add simple Travis CI configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root=true
+
+[.travis.yml]
+indent_style=space
+indent_size=2
+end_of_line = lf
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+sudo: required
+dist: trusty
+install:
+  - sudo apt-get -y update
+  - sudo apt-get -y install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi
+script:
+  - scripts/travis-build-firmware.sh
+

--- a/scripts/travis-build-firmware.sh
+++ b/scripts/travis-build-firmware.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Log commands and exit on error
+set -xe
+
+# Test-builds the firmware on Travis.
+# Required packages: gcc-arm-none-eabi libnewlib-arm-none-eabi
+
+mkdir build-fw
+cd build-fw
+cmake \
+	-DBUILD_FIRMWARE=ON \
+	-DCMAKE_TOOLCHAIN_FILE=../Toolchain-arm-none-eabi.cmake \
+	..
+make VERBOSE=1
+


### PR DESCRIPTION
Add .travis.yml and associated .editorconfig to support a minimal build of the
firmware on Travis CI.

The configuration selects Trusty as the build machine since it is the earliest
version of Ubuntu LTS which includes the ARM GCC toolchain. (And the only one
available on Travis.)
