### PR TITLE
README: add build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # state-estimators
 
+[![Build Status](https://travis-ci.org/cuspaceflight/state-estimators.svg)](https://travis-ci.org/cuspaceflight/state-estimators)
+
 ## Compilation
 
 * The project can be configured to build in one of two ways: to build the device firmware or to build the GUI.


### PR DESCRIPTION
If one clicks on the badge on Travis, it'll give you the markdown magic to
include the badge in your README. Let's be like the cool kids and add one.
