### PR TITLE
MPU9250 tidy-ups and gyro self-test

### DIFF
--- a/Avionics.Firmware/.editorconfig
+++ b/Avionics.Firmware/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,h}]
+indent_style=space
+indent_size=4

--- a/Avionics.Firmware/compilermacros.h
+++ b/Avionics.Firmware/compilermacros.h
@@ -1,0 +1,23 @@
+// compilermacros.h - convenience macros for the compiler
+//
+// Macros and definitions which allow use of non-standard features of the
+// compiler or to annotate extra information.
+#pragma once
+#ifndef COMPILER_MACROS_H
+#define COMPILER_MACROS_H
+
+// COMPILER_UNUSED_ARG is a macro which wraps function parameters in function
+// definitions which are unused by the body. It is a no-op in terms of
+// functionality but will silence unused argument warnings. Using it is more
+// explicit than added, e.g., "(void)argname" to the function body.
+//
+// Example:
+//  int foo(COMPILER_UNUSED_ARG(int bar)) { return 1; }
+//
+#ifdef __GNUC__
+#   define COMPILER_UNUSED_ARG(arg) arg __attribute__((unused))
+#else
+#   define COMPILER_UNUSED_ARG(arg) arg
+#endif
+
+#endif // COMPILER_MACROS_H

--- a/Avionics.Firmware/mpu9250-reg.h
+++ b/Avionics.Firmware/mpu9250-reg.h
@@ -1,0 +1,103 @@
+// mpu9250-reg.h contains human-readable name to register mapping for the
+// MPU9250. It also contains useful constants for setting/interpreting those
+// register contents.
+#pragma once
+#ifndef MPU9250_REG_H
+#define MPU9250_REG_H
+
+// MPU9250 registers
+enum {
+    // R/W registers unless noted otherwise
+
+    MPU9250_REG_SELF_TEST_X_GYRO = 0,
+    MPU9250_REG_SELF_TEST_Y_GYRO = 1,
+    MPU9250_REG_SELF_TEST_Z_GYRO = 2,
+
+    MPU9250_REG_SELF_TEST_X_ACCEL = 13,
+    MPU9250_REG_SELF_TEST_Y_ACCEL = 14,
+    MPU9250_REG_SELF_TEST_Z_ACCEL = 15,
+
+    MPU9250_REG_XG_OFFSET_H = 19,
+    MPU9250_REG_XG_OFFSET_L = 20,
+    MPU9250_REG_YG_OFFSET_H = 21,
+    MPU9250_REG_YG_OFFSET_L = 22,
+    MPU9250_REG_ZG_OFFSET_H = 23,
+    MPU9250_REG_ZG_OFFSET_L = 24,
+
+    MPU9250_REG_SMPLRT_DIV = 25,
+
+    MPU9250_REG_CONFIG = 26,
+    MPU9250_REG_GYRO_CONFIG = 27,
+    MPU9250_REG_ACCEL_CONFIG = 28,
+    MPU9250_REG_ACCEL_CONFIG_2 = 29,
+    MPU9250_REG_LP_ACCEL_ODR = 30,
+    MPU9250_REG_WOM_THR = 31,
+
+    MPU9250_REG_FIFO_EN = 35,
+
+    // TODO: add I2C registers
+
+    MPU9250_REG_INT_PIN_CFG = 55,
+    MPU9250_REG_INT_ENABLE = 56,
+    MPU9250_REG_INT_STATUS = 58, // read-only
+
+    // Read only output registers
+
+    MPU9250_REG_ACCEL_XOUT_H = 59,
+    MPU9250_REG_ACCEL_XOUT_L = 60,
+    MPU9250_REG_ACCEL_YOUT_H = 61,
+    MPU9250_REG_ACCEL_YOUT_L = 62,
+    MPU9250_REG_ACCEL_ZOUT_H = 63,
+    MPU9250_REG_ACCEL_ZOUT_L = 64,
+
+    MPU9250_REG_TEMP_OUT_H = 65,
+    MPU9250_REG_TEMP_OUT_L = 66,
+
+    MPU9250_REG_GYRO_XOUT_H = 67,
+    MPU9250_REG_GYRO_XOUT_L = 68,
+    MPU9250_REG_GYRO_YOUT_H = 69,
+    MPU9250_REG_GYRO_YOUT_L = 70,
+    MPU9250_REG_GYRO_ZOUT_H = 71,
+    MPU9250_REG_GYRO_ZOUT_L = 72,
+
+    // TODO: EXT_SENS_... and I2C_SLV... registers
+
+    // R/W again from here unless otherwise noted
+
+    MPU9250_REG_SIGNAL_PATH_RESET = 104,
+    MPU9250_REG_MOT_DETECT_CTRL = 105,
+    MPU9250_REG_USER_CTRL = 106,
+    MPU9250_REG_PWR_MGMT_1 = 107,
+    MPU9250_REG_PWR_MGMT_2 = 108,
+
+    MPU9250_REG_FIFO_COUNTH = 114,
+    MPU9250_REG_FIFO_COUNTL = 115,
+    MPU9250_REG_FIFO_R_W = 116,
+
+    MPU9250_REG_WHO_AM_I = 117, // read-only
+
+    MPU9250_REG_XA_OFFSET_H = 119,
+    MPU9250_REG_XA_OFFSET_L = 120,
+    MPU9250_REG_YA_OFFSET_H = 122,
+    MPU9250_REG_YA_OFFSET_L = 123,
+    MPU9250_REG_ZA_OFFSET_H = 125,
+    MPU9250_REG_ZA_OFFSET_L = 126,
+};
+
+// MPU9250 reset values. All register have a reset value of 0x00 apart from the
+// ones noted below.
+#define MPU9250_DEFAULT_RESET_VALUE 0x00
+#define MPU9250_PWR_MGMT_1_RESET_VALUE 0x01
+#define MPU9250_WHO_AM_I_RESET_VALUE 0x71
+
+// bytes_to_uint16 is a macro for taking a high and low byte value and forming a
+// uint16_t value from them.
+#define bytes_to_uint16(high, low) \
+    ( (((uint16_t)(high)) << 8) | ((uint16_t)(low)) )
+
+// bytes_to_int16 is a macro for taking a high and low byte value and forming a
+// int16_t value from them.
+#define bytes_to_int16(high, low) \
+    ( (((int16_t)(high)) << 8) | ((int16_t)(low)) )
+
+#endif // MPU9250_REG_H

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -3,6 +3,7 @@
 #include "chprintf.h"
 #include "mpu9250.h"
 #include "badthinghandler.h"
+#include "compilermacros.h"
 
 #define MPU9250_SPID         SPID1
 #define MPU9250_SPI_CS_PORT  GPIOA
@@ -104,8 +105,7 @@ void mpu9250_wakeup(EXTDriver *extp, expchannel_t channel) {
     chSysUnlockFromIsr();
 }
 
-msg_t mpu9250_thread(void *arg) {
-    (void)arg;
+msg_t mpu9250_thread(COMPILER_UNUSED_ARG(void *arg)) {
     const SPIConfig spi_cfg = {
         NULL,
         MPU9250_SPI_CS_PORT,

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -303,9 +303,11 @@ msg_t mpu9250_thread(COMPILER_UNUSED_ARG(void *arg)) {
     mpu9250_init();
 
     // Perform a self-test of the MPU9250
-    if(!mpu9250_self_test()) {
+    while(!mpu9250_self_test()) {
         bthandler_set_error(ERROR_MPU9250, true);
+        chThdSleepMilliseconds(50);
     }
+    bthandler_set_error(ERROR_MPU9250, false);
 
     uint16_t raw_data[10];
     while(TRUE) {

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -1,4 +1,6 @@
 #include <stdlib.h>
+#include <math.h> // for self-test
+
 #include "ch.h"
 #include "chprintf.h"
 #include "mpu9250.h"
@@ -30,6 +32,10 @@ static void mpu9250_write_u8(uint8_t addr, uint8_t val);
 // mpu9250_id_check performs a simple sanity check on MPU9250 communication by
 // checking that the WHO_AM_I register of the MPU9250 has an expected value.
 static bool mpu9250_id_check(void);
+
+// mpu9250_self_test_gyro performs a self-test on the gyro, compares the result
+// to the factory stored values and returns true iff the self-test succeeds.
+static bool mpu9250_self_test_gyro(void);
 
 static uint8_t mpu9250_read_u8(uint8_t addr) {
     // Set the read bit
@@ -106,14 +112,113 @@ static bool mpu9250_id_check(void) {
     return whoami == MPU9250_WHO_AM_I_RESET_VALUE;
 }
 
+// Take the mean of the three measurement values represented by the six
+// registers starting at base_reg. Write 16-bit results to the buffer pointed to
+// by out. The behaviour is to sample 256 values at 1KHz and return the mean.
+static void mpu9250_read_mean_triplet(uint8_t base_reg, int16_t *out) {
+    uint8_t sensor_values[6];
+    int32_t sensor_accumulator[3] = {0, 0, 0};
+
+    // Accumulate 256 readings
+    for(int i=0; i<256; ++i) {
+        // Read gyro values
+        mpu9250_read_multiple(base_reg, sensor_values, 6);
+
+        sensor_accumulator[0] += (int32_t)bytes_to_uint16(
+            sensor_values[0], sensor_values[1]);
+        sensor_accumulator[1] += (int32_t)bytes_to_uint16(
+            sensor_values[2], sensor_values[3]);
+        sensor_accumulator[2] += (int32_t)bytes_to_uint16(
+            sensor_values[4], sensor_values[5]);
+
+        chThdSleepMilliseconds(1);
+    }
+
+    // Shift right to take mean and record
+    for(int i=0; i<3; ++i) {
+        sensor_accumulator[i] >>= 8;
+        out[i] = sensor_accumulator[i];
+    }
+}
+
+// mpu9250_self_test_to_factory_trim takes self-test register values and
+// transforms them to the corresponding factory trim values which should match
+// the sensor readings. (It is assumed that the full-scale select is 00 ==
+// +/-250 deg/sec.) It appears non-trivial to find the application note which
+// describes the self-test procedure. This formula was lifted from [1].
+//
+// [1] https://github.com/kriswiner/MPU-9250/blob/master/MPU9250BasicAHRS.ino
+static inline int16_t mpu9250_self_test_to_factory_trim(uint8_t st_val) {
+    return (int16_t)(2620.f * powf(1.01f, ((float)st_val) - 1.f));
+}
+
+static bool mpu9250_self_test_gyro(void) {
+    uint8_t factory_st_output[3], old_gyro_config;
+    int16_t base_values[3], self_test_values[3];
+
+    // Read old gyro config
+    old_gyro_config = mpu9250_read_u8(MPU9250_REG_GYRO_CONFIG);
+
+    // Gyro config => range of +/- 250 degrees/sec
+    mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, 0x00);
+
+    // Delay for a short while to let device stabilise
+    chThdSleepMilliseconds(50);
+
+    // Record mean of incoming values
+    mpu9250_read_mean_triplet(MPU9250_REG_GYRO_XOUT_H, base_values);
+
+    // Set gyro config to self test on all axes with gyro range of +/- 250
+    // degrees/s
+    mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, 0xe0);
+
+    // Delay for a short while to let device stabilise
+    chThdSleepMilliseconds(50);
+
+    // Record mean of incoming values
+    mpu9250_read_mean_triplet(MPU9250_REG_GYRO_XOUT_H, self_test_values);
+
+    // Restore old gyro config
+    mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, old_gyro_config);
+
+    // Subtract base readings from self_test_values.
+    for(int i=0; i<3; ++i) {
+        self_test_values[i] -= base_values[i];
+    }
+
+    // Read factory self-test output
+    mpu9250_read_multiple(MPU9250_REG_SELF_TEST_X_GYRO, factory_st_output, 3);
+
+    // Convert this to expected values for self-test output and check absolute
+    // difference from measured. Fail if the difference is greater than 5% of
+    // the expected value.
+    for(int i=0; i<3; ++i) {
+        int16_t expected_val = mpu9250_self_test_to_factory_trim(
+            factory_st_output[i]);
+        int32_t delta = (int32_t)self_test_values[i] - (int32_t)expected_val;
+        if(abs(delta) > abs(expected_val)/20) {
+            // We fail :(
+            return false;
+        }
+    }
+
+    // Self test passed!
+    return true;
+}
+
 static void mpu9250_init(void) {
-    // Set User Control Register - Disable FIFO, Disable I2C
-    mpu9250_write_u8(0x6A, 0x10);
+    // Register/value pairs to reset/initialise MPU9250
+    uint8_t init_sequence[][2] = {
+        { MPU9250_REG_PWR_MGMT_1, 0x80 }, // Reset
+        { MPU9250_REG_PWR_MGMT_1, 0x00 }, // Select internal 20MHz source
+        { MPU9250_REG_PWR_MGMT_2, 0x00 }, // Enable gyro & accel
+        { MPU9250_REG_USER_CTRL, 0x10 }, // SPI only, sidable FIFO
+    };
 
-    // TODO: Initialize sensor - setting control registers to appropriate values
-
-
-    // TODO: Perform self test
+    // Perform initial reset
+    for(size_t i=0; i < sizeof(init_sequence)/sizeof(init_sequence[0]); ++i) {
+        mpu9250_write_u8(init_sequence[i][0], init_sequence[i][1]);
+    }
 }
 
 void mpu9250_wakeup(EXTDriver *extp, expchannel_t channel) {
@@ -151,6 +256,11 @@ msg_t mpu9250_thread(COMPILER_UNUSED_ARG(void *arg)) {
     bthandler_set_error(ERROR_MPU9250, false);
 
     mpu9250_init();
+
+    // Perform a self-test of the MPU9250
+    if(!mpu9250_self_test_gyro()) {
+        bthandler_set_error(ERROR_MPU9250, true);
+    }
 
     uint16_t raw_data[10];
     while(TRUE) {

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -33,9 +33,9 @@ static void mpu9250_write_u8(uint8_t addr, uint8_t val);
 // checking that the WHO_AM_I register of the MPU9250 has an expected value.
 static bool mpu9250_id_check(void);
 
-// mpu9250_self_test_gyro performs a self-test on the gyro, compares the result
-// to the factory stored values and returns true iff the self-test succeeds.
-static bool mpu9250_self_test_gyro(void);
+// mpu9250_self_test performs a self-test on the gyroscope and accelerometer. It
+// returns true iff the self-test passed.
+static bool mpu9250_self_test(void);
 
 static uint8_t mpu9250_read_u8(uint8_t addr) {
     // Set the read bit
@@ -112,23 +112,37 @@ static bool mpu9250_id_check(void) {
     return whoami == MPU9250_WHO_AM_I_RESET_VALUE;
 }
 
-// Take the mean of the three measurement values represented by the six
-// registers starting at base_reg. Write 16-bit results to the buffer pointed to
-// by out. The behaviour is to sample 256 values at 1KHz and return the mean.
-static void mpu9250_read_mean_triplet(uint8_t base_reg, int16_t *out) {
+// mpu9250_read_mean_accel_gyro will take the mean of the accelerometer and
+// gyroscope values. Write 16-bit results to the buffers pointed to by out_accel
+// and out_gyro. The behaviour is to sample 256 values at 1KHz and return the
+// mean.
+static void mpu9250_read_mean_accel_gyro(int16_t *accel_out,
+                                         int16_t *gyro_out)
+{
     uint8_t sensor_values[6];
-    int32_t sensor_accumulator[3] = {0, 0, 0};
+    int32_t accel_sensor_accumulator[3] = {0, 0, 0};
+    int32_t gyro_sensor_accumulator[3] = {0, 0, 0};
 
     // Accumulate 256 readings
     for(int i=0; i<256; ++i) {
-        // Read gyro values
-        mpu9250_read_multiple(base_reg, sensor_values, 6);
+        // Accelerometer
+        mpu9250_read_multiple(MPU9250_REG_ACCEL_XOUT_H, sensor_values, 6);
 
-        sensor_accumulator[0] += (int32_t)bytes_to_uint16(
+        accel_sensor_accumulator[0] += (int32_t)bytes_to_uint16(
             sensor_values[0], sensor_values[1]);
-        sensor_accumulator[1] += (int32_t)bytes_to_uint16(
+        accel_sensor_accumulator[1] += (int32_t)bytes_to_uint16(
             sensor_values[2], sensor_values[3]);
-        sensor_accumulator[2] += (int32_t)bytes_to_uint16(
+        accel_sensor_accumulator[2] += (int32_t)bytes_to_uint16(
+            sensor_values[4], sensor_values[5]);
+
+        // Gyro
+        mpu9250_read_multiple(MPU9250_REG_GYRO_XOUT_H, sensor_values, 6);
+
+        gyro_sensor_accumulator[0] += (int32_t)bytes_to_uint16(
+            sensor_values[0], sensor_values[1]);
+        gyro_sensor_accumulator[1] += (int32_t)bytes_to_uint16(
+            sensor_values[2], sensor_values[3]);
+        gyro_sensor_accumulator[2] += (int32_t)bytes_to_uint16(
             sensor_values[4], sensor_values[5]);
 
         chThdSleepMilliseconds(1);
@@ -136,8 +150,10 @@ static void mpu9250_read_mean_triplet(uint8_t base_reg, int16_t *out) {
 
     // Shift right to take mean and record
     for(int i=0; i<3; ++i) {
-        sensor_accumulator[i] >>= 8;
-        out[i] = sensor_accumulator[i];
+        accel_sensor_accumulator[i] >>= 8;
+        accel_out[i] = accel_sensor_accumulator[i];
+        gyro_sensor_accumulator[i] >>= 8;
+        gyro_out[i] = gyro_sensor_accumulator[i];
     }
 }
 
@@ -152,41 +168,54 @@ static inline int16_t mpu9250_self_test_to_factory_trim(uint8_t st_val) {
     return (int16_t)(2620.f * powf(1.01f, ((float)st_val) - 1.f));
 }
 
-static bool mpu9250_self_test_gyro(void) {
-    uint8_t factory_st_output[3], old_gyro_config;
-    int16_t base_values[3], self_test_values[3];
+static bool mpu9250_self_test(void) {
+    uint8_t old_gyro_config, old_accel_config, old_accel_config_2;
+    int16_t base_accel[3], base_gyro[3], self_test_accel[3], self_test_gyro[3];
+    uint8_t factory_st_output[3];
 
-    // Read old gyro config
+    // Read old configs
     old_gyro_config = mpu9250_read_u8(MPU9250_REG_GYRO_CONFIG);
+    old_accel_config = mpu9250_read_u8(MPU9250_REG_ACCEL_CONFIG);
+    old_accel_config_2 = mpu9250_read_u8(MPU9250_REG_ACCEL_CONFIG_2);
 
     // Gyro config => range of +/- 250 degrees/sec
     mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, 0x00);
+
+    // Accel config => +/- 2g
+    mpu9250_write_u8(MPU9250_REG_ACCEL_CONFIG, 0x00);
+    mpu9250_write_u8(MPU9250_REG_ACCEL_CONFIG_2, 0x00);
 
     // Delay for a short while to let device stabilise
     chThdSleepMilliseconds(50);
 
     // Record mean of incoming values
-    mpu9250_read_mean_triplet(MPU9250_REG_GYRO_XOUT_H, base_values);
+    mpu9250_read_mean_accel_gyro(base_accel, base_gyro);
 
     // Set gyro config to self test on all axes with gyro range of +/- 250
     // degrees/s
     mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, 0xe0);
 
+    // Set accel config to self test on all axes with accel range of +/- 2g
+    mpu9250_write_u8(MPU9250_REG_ACCEL_CONFIG, 0xe0);
+
     // Delay for a short while to let device stabilise
     chThdSleepMilliseconds(50);
 
     // Record mean of incoming values
-    mpu9250_read_mean_triplet(MPU9250_REG_GYRO_XOUT_H, self_test_values);
+    mpu9250_read_mean_accel_gyro(self_test_accel, self_test_gyro);
 
-    // Restore old gyro config
+    // Restore old configs
     mpu9250_write_u8(MPU9250_REG_GYRO_CONFIG, old_gyro_config);
+    mpu9250_write_u8(MPU9250_REG_ACCEL_CONFIG, old_accel_config);
+    mpu9250_write_u8(MPU9250_REG_ACCEL_CONFIG_2, old_accel_config_2);
 
     // Subtract base readings from self_test_values.
     for(int i=0; i<3; ++i) {
-        self_test_values[i] -= base_values[i];
+        self_test_accel[i] -= base_accel[i];
+        self_test_gyro[i] -= base_gyro[i];
     }
 
-    // Read factory self-test output
+    // Read factory self-test output for gyro
     mpu9250_read_multiple(MPU9250_REG_SELF_TEST_X_GYRO, factory_st_output, 3);
 
     // Convert this to expected values for self-test output and check absolute
@@ -195,7 +224,23 @@ static bool mpu9250_self_test_gyro(void) {
     for(int i=0; i<3; ++i) {
         int16_t expected_val = mpu9250_self_test_to_factory_trim(
             factory_st_output[i]);
-        int32_t delta = (int32_t)self_test_values[i] - (int32_t)expected_val;
+        int32_t delta = (int32_t)self_test_gyro[i] - (int32_t)expected_val;
+        if(abs(delta) > abs(expected_val)/20) {
+            // We fail :(
+            return false;
+        }
+    }
+
+    // Read factory self-test output for accelerometer
+    mpu9250_read_multiple(MPU9250_REG_SELF_TEST_X_ACCEL, factory_st_output, 3);
+
+    // Convert this to expected values for self-test output and check absolute
+    // difference from measured. Fail if the difference is greater than 5% of
+    // the expected value.
+    for(int i=0; i<3; ++i) {
+        int16_t expected_val = mpu9250_self_test_to_factory_trim(
+            factory_st_output[i]);
+        int32_t delta = (int32_t)self_test_accel[i] - (int32_t)expected_val;
         if(abs(delta) > abs(expected_val)/20) {
             // We fail :(
             return false;
@@ -258,7 +303,7 @@ msg_t mpu9250_thread(COMPILER_UNUSED_ARG(void *arg)) {
     mpu9250_init();
 
     // Perform a self-test of the MPU9250
-    if(!mpu9250_self_test_gyro()) {
+    if(!mpu9250_self_test()) {
         bthandler_set_error(ERROR_MPU9250, true);
     }
 

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -11,6 +11,33 @@
 
 static BinarySemaphore mpu9250_semaphore;
 
+// MPU9250 registers
+enum {
+    MPU9250_REG_WHOAMI = 117,
+};
+
+// MPU9250 constants
+#define MPU9250_WHOAMI_DEFAULT_VALUE 0x71
+
+//// LOW-LEVEL COMMUNICATION ////
+
+// mpu9250_read_u8 reads a single byte value from an 8-bit MPU9250 register
+static uint8_t mpu9250_read_u8(uint8_t addr);
+
+// mpu9250_read_multiple reads a multi-byte register from the MPU9250 into a
+// memory buffer. The buffer pointed to by buf should have at least num bytes
+// available.
+static void mpu9250_read_multiple(uint8_t addr, uint8_t* buf, int num);
+
+// mpu9250_write_u8 writes a single byte into an 8-bit MPU9250 register.
+static void mpu9250_write_u8(uint8_t addr, uint8_t val);
+
+//// HIGH-LEVEL OPERATIONS ////
+
+// mpu9250_id_check performs a simple sanity check on MPU9250 communication by
+// checking that the WHOAMI register of the MPU9250 has an expected value.
+static bool mpu9250_id_check(void);
+
 static uint8_t mpu9250_read_u8(uint8_t addr) {
     // Set the read bit
     addr |= (1 << 7);
@@ -82,8 +109,8 @@ static void mpu9250_burst_read(uint16_t data_out[10]) {
 
 static bool mpu9250_id_check(void) {
     // Read WHOAMI Register
-    uint8_t whoami = mpu9250_read_u8(0x75);
-    return whoami == 0x71;
+    uint8_t whoami = mpu9250_read_u8(MPU9250_REG_WHOAMI);
+    return whoami == MPU9250_WHOAMI_DEFAULT_VALUE;
 }
 
 static void mpu9250_init(void) {

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -4,20 +4,13 @@
 #include "mpu9250.h"
 #include "badthinghandler.h"
 #include "compilermacros.h"
+#include "mpu9250-reg.h"
 
 #define MPU9250_SPID         SPID1
 #define MPU9250_SPI_CS_PORT  GPIOA
 #define MPU9250_SPI_CS_PIN   GPIOA_MPU_NSS
 
 static BinarySemaphore mpu9250_semaphore;
-
-// MPU9250 registers
-enum {
-    MPU9250_REG_WHOAMI = 117,
-};
-
-// MPU9250 constants
-#define MPU9250_WHOAMI_DEFAULT_VALUE 0x71
 
 //// LOW-LEVEL COMMUNICATION ////
 
@@ -35,7 +28,7 @@ static void mpu9250_write_u8(uint8_t addr, uint8_t val);
 //// HIGH-LEVEL OPERATIONS ////
 
 // mpu9250_id_check performs a simple sanity check on MPU9250 communication by
-// checking that the WHOAMI register of the MPU9250 has an expected value.
+// checking that the WHO_AM_I register of the MPU9250 has an expected value.
 static bool mpu9250_id_check(void);
 
 static uint8_t mpu9250_read_u8(uint8_t addr) {
@@ -108,9 +101,9 @@ static void mpu9250_burst_read(uint16_t data_out[10]) {
 }
 
 static bool mpu9250_id_check(void) {
-    // Read WHOAMI Register
-    uint8_t whoami = mpu9250_read_u8(MPU9250_REG_WHOAMI);
-    return whoami == MPU9250_WHOAMI_DEFAULT_VALUE;
+    // Read WHO_AM_I Register
+    uint8_t whoami = mpu9250_read_u8(MPU9250_REG_WHO_AM_I);
+    return whoami == MPU9250_WHO_AM_I_RESET_VALUE;
 }
 
 static void mpu9250_init(void) {

--- a/Avionics.Firmware/mpu9250.c
+++ b/Avionics.Firmware/mpu9250.c
@@ -212,7 +212,7 @@ static void mpu9250_init(void) {
         { MPU9250_REG_PWR_MGMT_1, 0x80 }, // Reset
         { MPU9250_REG_PWR_MGMT_1, 0x00 }, // Select internal 20MHz source
         { MPU9250_REG_PWR_MGMT_2, 0x00 }, // Enable gyro & accel
-        { MPU9250_REG_USER_CTRL, 0x10 }, // SPI only, sidable FIFO
+        { MPU9250_REG_USER_CTRL, 0x10 }, // SPI only, disable FIFO
     };
 
     // Perform initial reset


### PR DESCRIPTION
Not much here beyond a few tidy-ups. Specifically:
1. Add some editor configuration (like in the root) specifying indent style, etc. (I spotted some tab/spaces confusion elsewhere)
2. Make it more explicit to humans that we intentionally ignore the argumnt passed to mpu9250_thread().

Item 2 is implemented as a macro which uses `__attribute__((unused))` on GCC and is a no-op on other compilers.

**Update:** As noted in the subject, I've gone ahead and implemented the self-test algorithm.
