### PR TITLE
Implement a USB serial console

### DIFF
--- a/Avionics.Firmware/Makefile
+++ b/Avionics.Firmware/Makefile
@@ -99,7 +99,7 @@ CSRC = $(PORTSRC) \
        $(CHIBIOS)/os/various/syscalls.c \
        $(CHIBIOS)/os/various/shell.c \
        main.c adis16405.c platform_firmware.c badthinghandler.c mpu9250.c \
-       ms5611.c usbcfg.c
+       ms5611.c usbcfg.c serialconsole.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.

--- a/Avionics.Firmware/Makefile
+++ b/Avionics.Firmware/Makefile
@@ -98,7 +98,8 @@ CSRC = $(PORTSRC) \
        $(CHIBIOS)/os/various/chprintf.c \
        $(CHIBIOS)/os/various/syscalls.c \
        $(CHIBIOS)/os/various/shell.c \
-       main.c adis16405.c platform_firmware.c badthinghandler.c mpu9250.c ms5611.c
+       main.c adis16405.c platform_firmware.c badthinghandler.c mpu9250.c \
+       ms5611.c usbcfg.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.

--- a/Avionics.Firmware/board.h
+++ b/Avionics.Firmware/board.h
@@ -35,6 +35,11 @@
 #define STM32F40_41xxx
 
 /*
+ * Disable MCU's VBUS sensing. (Otherwise VBUS would have to be wired to PA9.)
+ */
+#define BOARD_OTG_NOVBUSSENS
+
+/*
  * IO pins assignments.
  */
 #define GPIOA_PIN0                  0

--- a/Avionics.Firmware/halconf.h
+++ b/Avionics.Firmware/halconf.h
@@ -132,7 +132,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          FALSE
+#define HAL_USE_SERIAL_USB          TRUE
 #endif
 
 /**
@@ -153,7 +153,7 @@
  * @brief   Enables the USB subsystem.
  */
 #if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
-#define HAL_USE_USB                 FALSE
+#define HAL_USE_USB                 TRUE
 #endif
 
 /*===========================================================================*/

--- a/Avionics.Firmware/main.c
+++ b/Avionics.Firmware/main.c
@@ -4,11 +4,13 @@
 #include "mpu9250.h"
 #include "ms5611.h"
 #include "badthinghandler.h"
+#include "serialconsole.h"
 
 //static WORKING_AREA(waMission, 1024);
 
 static WORKING_AREA(waMPU, 2048);
 static WORKING_AREA(waBadThing, 1024);
+static WORKING_AREA(waSerialConsole, 512);
 //static WORKING_AREA(waMS5611, 768);
 
 /*
@@ -61,6 +63,8 @@ int main(void) {
     chThdCreateStatic(waBadThing, sizeof(waBadThing), NORMALPRIO, bthandler_thread, NULL);
     chThdCreateStatic(waMPU, sizeof(waMPU), NORMALPRIO, mpu9250_thread, NULL);
     //chThdCreateStatic(waMS5611, sizeof(waMS5611), NORMALPRIO, ms5611_thread, NULL);
+    chThdCreateStatic(waSerialConsole, sizeof(waSerialConsole), NORMALPRIO,
+                      serial_console_thread, NULL);
     extStart(&EXTD1, &extcfg);
 
     while (TRUE) {

--- a/Avionics.Firmware/mcuconf.h
+++ b/Avionics.Firmware/mcuconf.h
@@ -277,7 +277,7 @@
 /*
  * USB driver system settings.
  */
-#define STM32_USB_USE_OTG1                  FALSE
+#define STM32_USB_USE_OTG1                  TRUE
 #define STM32_USB_USE_OTG2                  FALSE
 #define STM32_USB_OTG1_IRQ_PRIORITY         14
 #define STM32_USB_OTG2_IRQ_PRIORITY         14

--- a/Avionics.Firmware/serialconsole.c
+++ b/Avionics.Firmware/serialconsole.c
@@ -1,0 +1,61 @@
+#include "ch.h"
+#include "hal.h"
+#include "shell.h"
+
+#include "usbcfg.h"
+#include "serialconsole.h"
+#include "compilermacros.h"
+
+/* Virtual serial port over USB.*/
+SerialUSBDriver SDU1;
+
+static const ShellCommand commands[] = {
+  {NULL, NULL}
+};
+
+static const ShellConfig shell_cfg1 = {
+  (BaseSequentialStream *)&SDU1,
+  commands
+};
+
+#define SHELL_WA_SIZE   THD_WA_SIZE(2048)
+
+msg_t serial_console_thread(COMPILER_UNUSED_ARG(void *arg)) {
+    Thread *shelltp = NULL;
+
+    chRegSetThreadName("Serial Console");
+
+    // Initializes a serial-over-USB CDC driver.
+    sduObjectInit(&SDU1);
+    sduStart(&SDU1, &serusbcfg);
+
+    // Activates the USB driver and then the USB bus pull-up on D+.
+    // Note, a delay is inserted in order to not have to disconnect the cable
+    // after a reset.
+    usbDisconnectBus(serusbcfg.usbp);
+    chThdSleepMilliseconds(1000);
+    usbStart(serusbcfg.usbp, &usbcfg);
+    usbConnectBus(serusbcfg.usbp);
+
+    while(TRUE) {
+        if (!shelltp) {
+            if (SDU1.config->usbp->state == USB_ACTIVE) {
+                /* Spawns a new shell.*/
+                shelltp = shellCreate(&shell_cfg1, SHELL_WA_SIZE, NORMALPRIO);
+            }
+        }
+        else {
+            /* If the previous shell exited.*/
+            if (chThdTerminated(shelltp)) {
+              /* Recovers memory of the previous shell.*/
+              chThdRelease(shelltp);
+              shelltp = NULL;
+            }
+        }
+        chThdSleepMilliseconds(500);
+    }
+}
+
+bool serial_console_is_active(void) {
+    return SDU1.config->usbp->state == USB_ACTIVE;
+}

--- a/Avionics.Firmware/serialconsole.h
+++ b/Avionics.Firmware/serialconsole.h
@@ -1,0 +1,13 @@
+// serialconsole.h contains public declarations for serial-over-USB
+// functionality.
+#pragma once
+#ifndef SERIAL_CONSOLE__H
+#define SERIAL_CONSOLE__H
+
+// serial_console_thread initialises a USB serial interface and wires it up to
+// the serial console.
+msg_t serial_console_thread(void *arg);
+
+bool serial_console_is_active(void);
+
+#endif // SERIAL_CONSOLE__H

--- a/Avionics.Firmware/usbcfg.c
+++ b/Avionics.Firmware/usbcfg.c
@@ -1,0 +1,314 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+/*
+ * Endpoints to be used for USBD1.
+ */
+#define USBD1_DATA_REQUEST_EP           1
+#define USBD1_DATA_AVAILABLE_EP         1
+#define USBD1_INTERRUPT_REQUEST_EP      2
+
+/*
+ * USB Device Descriptor.
+ */
+static const uint8_t vcom_device_descriptor_data[18] = {
+  USB_DESC_DEVICE       (0x0110,        /* bcdUSB (1.1).                    */
+                         0x02,          /* bDeviceClass (CDC).              */
+                         0x00,          /* bDeviceSubClass.                 */
+                         0x00,          /* bDeviceProtocol.                 */
+                         0x40,          /* bMaxPacketSize.                  */
+                         0x0483,        /* idVendor (ST).                   */
+                         0x5740,        /* idProduct.                       */
+                         0x0200,        /* bcdDevice.                       */
+                         1,             /* iManufacturer.                   */
+                         2,             /* iProduct.                        */
+                         3,             /* iSerialNumber.                   */
+                         1)             /* bNumConfigurations.              */
+};
+
+/*
+ * Device Descriptor wrapper.
+ */
+static const USBDescriptor vcom_device_descriptor = {
+  sizeof vcom_device_descriptor_data,
+  vcom_device_descriptor_data
+};
+
+/* Configuration Descriptor tree for a CDC.*/
+static const uint8_t vcom_configuration_descriptor_data[67] = {
+  /* Configuration Descriptor.*/
+  USB_DESC_CONFIGURATION(67,            /* wTotalLength.                    */
+                         0x02,          /* bNumInterfaces.                  */
+                         0x01,          /* bConfigurationValue.             */
+                         0,             /* iConfiguration.                  */
+                         0xC0,          /* bmAttributes (self powered).     */
+                         50),           /* bMaxPower (100mA).               */
+  /* Interface Descriptor.*/
+  USB_DESC_INTERFACE    (0x00,          /* bInterfaceNumber.                */
+                         0x00,          /* bAlternateSetting.               */
+                         0x01,          /* bNumEndpoints.                   */
+                         0x02,          /* bInterfaceClass (Communications
+                                           Interface Class, CDC section
+                                           4.2).                            */
+                         0x02,          /* bInterfaceSubClass (Abstract
+                                         Control Model, CDC section 4.3).   */
+                         0x01,          /* bInterfaceProtocol (AT commands,
+                                           CDC section 4.4).                */
+                         0),            /* iInterface.                      */
+  /* Header Functional Descriptor (CDC section 5.2.3).*/
+  USB_DESC_BYTE         (5),            /* bLength.                         */
+  USB_DESC_BYTE         (0x24),         /* bDescriptorType (CS_INTERFACE).  */
+  USB_DESC_BYTE         (0x00),         /* bDescriptorSubtype (Header
+                                           Functional Descriptor.           */
+  USB_DESC_BCD          (0x0110),       /* bcdCDC.                          */
+  /* Call Management Functional Descriptor. */
+  USB_DESC_BYTE         (5),            /* bFunctionLength.                 */
+  USB_DESC_BYTE         (0x24),         /* bDescriptorType (CS_INTERFACE).  */
+  USB_DESC_BYTE         (0x01),         /* bDescriptorSubtype (Call Management
+                                           Functional Descriptor).          */
+  USB_DESC_BYTE         (0x00),         /* bmCapabilities (D0+D1).          */
+  USB_DESC_BYTE         (0x01),         /* bDataInterface.                  */
+  /* ACM Functional Descriptor.*/
+  USB_DESC_BYTE         (4),            /* bFunctionLength.                 */
+  USB_DESC_BYTE         (0x24),         /* bDescriptorType (CS_INTERFACE).  */
+  USB_DESC_BYTE         (0x02),         /* bDescriptorSubtype (Abstract
+                                           Control Management Descriptor).  */
+  USB_DESC_BYTE         (0x02),         /* bmCapabilities.                  */
+  /* Union Functional Descriptor.*/
+  USB_DESC_BYTE         (5),            /* bFunctionLength.                 */
+  USB_DESC_BYTE         (0x24),         /* bDescriptorType (CS_INTERFACE).  */
+  USB_DESC_BYTE         (0x06),         /* bDescriptorSubtype (Union
+                                           Functional Descriptor).          */
+  USB_DESC_BYTE         (0x00),         /* bMasterInterface (Communication
+                                           Class Interface).                */
+  USB_DESC_BYTE         (0x01),         /* bSlaveInterface0 (Data Class
+                                           Interface).                      */
+  /* Endpoint 2 Descriptor.*/
+  USB_DESC_ENDPOINT     (USBD1_INTERRUPT_REQUEST_EP|0x80,
+                         0x03,          /* bmAttributes (Interrupt).        */
+                         0x0008,        /* wMaxPacketSize.                  */
+                         0xFF),         /* bInterval.                       */
+  /* Interface Descriptor.*/
+  USB_DESC_INTERFACE    (0x01,          /* bInterfaceNumber.                */
+                         0x00,          /* bAlternateSetting.               */
+                         0x02,          /* bNumEndpoints.                   */
+                         0x0A,          /* bInterfaceClass (Data Class
+                                           Interface, CDC section 4.5).     */
+                         0x00,          /* bInterfaceSubClass (CDC section
+                                           4.6).                            */
+                         0x00,          /* bInterfaceProtocol (CDC section
+                                           4.7).                            */
+                         0x00),         /* iInterface.                      */
+  /* Endpoint 3 Descriptor.*/
+  USB_DESC_ENDPOINT     (USBD1_DATA_AVAILABLE_EP,       /* bEndpointAddress.*/
+                         0x02,          /* bmAttributes (Bulk).             */
+                         0x0040,        /* wMaxPacketSize.                  */
+                         0x00),         /* bInterval.                       */
+  /* Endpoint 1 Descriptor.*/
+  USB_DESC_ENDPOINT     (USBD1_DATA_REQUEST_EP|0x80,    /* bEndpointAddress.*/
+                         0x02,          /* bmAttributes (Bulk).             */
+                         0x0040,        /* wMaxPacketSize.                  */
+                         0x00)          /* bInterval.                       */
+};
+
+/*
+ * Configuration Descriptor wrapper.
+ */
+static const USBDescriptor vcom_configuration_descriptor = {
+  sizeof vcom_configuration_descriptor_data,
+  vcom_configuration_descriptor_data
+};
+
+/*
+ * U.S. English language identifier.
+ */
+static const uint8_t vcom_string0[] = {
+  USB_DESC_BYTE(4),                     /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  USB_DESC_WORD(0x0409)                 /* wLANGID (U.S. English).          */
+};
+
+/*
+ * Vendor string.
+ */
+static const uint8_t vcom_string1[] = {
+  USB_DESC_BYTE(38),                    /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  'S', 0, 'T', 0, 'M', 0, 'i', 0, 'c', 0, 'r', 0, 'o', 0, 'e', 0,
+  'l', 0, 'e', 0, 'c', 0, 't', 0, 'r', 0, 'o', 0, 'n', 0, 'i', 0,
+  'c', 0, 's', 0
+};
+
+/*
+ * Device Description string.
+ */
+static const uint8_t vcom_string2[] = {
+  USB_DESC_BYTE(56),                    /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  'C', 0, 'h', 0, 'i', 0, 'b', 0, 'i', 0, 'O', 0, 'S', 0, '/', 0,
+  'R', 0, 'T', 0, ' ', 0, 'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0,
+  'a', 0, 'l', 0, ' ', 0, 'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0,
+  'o', 0, 'r', 0, 't', 0
+};
+
+/*
+ * Serial Number string.
+ */
+static const uint8_t vcom_string3[] = {
+  USB_DESC_BYTE(8),                     /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  '0' + CH_KERNEL_MAJOR, 0,
+  '0' + CH_KERNEL_MINOR, 0,
+  '0' + CH_KERNEL_PATCH, 0
+};
+
+/*
+ * Strings wrappers array.
+ */
+static const USBDescriptor vcom_strings[] = {
+  {sizeof vcom_string0, vcom_string0},
+  {sizeof vcom_string1, vcom_string1},
+  {sizeof vcom_string2, vcom_string2},
+  {sizeof vcom_string3, vcom_string3}
+};
+
+/*
+ * Handles the GET_DESCRIPTOR callback. All required descriptors must be
+ * handled here.
+ */
+static const USBDescriptor *get_descriptor(USBDriver *usbp,
+                                           uint8_t dtype,
+                                           uint8_t dindex,
+                                           uint16_t lang) {
+
+  (void)usbp;
+  (void)lang;
+  switch (dtype) {
+  case USB_DESCRIPTOR_DEVICE:
+    return &vcom_device_descriptor;
+  case USB_DESCRIPTOR_CONFIGURATION:
+    return &vcom_configuration_descriptor;
+  case USB_DESCRIPTOR_STRING:
+    if (dindex < 4)
+      return &vcom_strings[dindex];
+  }
+  return NULL;
+}
+
+/**
+ * @brief   IN EP1 state.
+ */
+static USBInEndpointState ep1instate;
+
+/**
+ * @brief   OUT EP1 state.
+ */
+static USBOutEndpointState ep1outstate;
+
+/**
+ * @brief   EP1 initialization structure (both IN and OUT).
+ */
+static const USBEndpointConfig ep1config = {
+  USB_EP_MODE_TYPE_BULK,
+  NULL,
+  sduDataTransmitted,
+  sduDataReceived,
+  0x0040,
+  0x0040,
+  &ep1instate,
+  &ep1outstate,
+  2,
+  NULL
+};
+
+/**
+ * @brief   IN EP2 state.
+ */
+static USBInEndpointState ep2instate;
+
+/**
+ * @brief   EP2 initialization structure (IN only).
+ */
+static const USBEndpointConfig ep2config = {
+  USB_EP_MODE_TYPE_INTR,
+  NULL,
+  sduInterruptTransmitted,
+  NULL,
+  0x0010,
+  0x0000,
+  &ep2instate,
+  NULL,
+  1,
+  NULL
+};
+
+/*
+ * Handles the USB driver global events.
+ */
+static void usb_event(USBDriver *usbp, usbevent_t event) {
+  extern SerialUSBDriver SDU1;
+
+  switch (event) {
+  case USB_EVENT_RESET:
+    return;
+  case USB_EVENT_ADDRESS:
+    return;
+  case USB_EVENT_CONFIGURED:
+    chSysLockFromIsr();
+
+    /* Enables the endpoints specified into the configuration.
+       Note, this callback is invoked from an ISR so I-Class functions
+       must be used.*/
+    usbInitEndpointI(usbp, USBD1_DATA_REQUEST_EP, &ep1config);
+    usbInitEndpointI(usbp, USBD1_INTERRUPT_REQUEST_EP, &ep2config);
+
+    /* Resetting the state of the CDC subsystem.*/
+    sduConfigureHookI(&SDU1);
+
+    chSysUnlockFromIsr();
+    return;
+  case USB_EVENT_SUSPEND:
+    return;
+  case USB_EVENT_WAKEUP:
+    return;
+  case USB_EVENT_STALLED:
+    return;
+  }
+  return;
+}
+
+/*
+ * USB driver configuration.
+ */
+const USBConfig usbcfg = {
+  usb_event,
+  get_descriptor,
+  sduRequestsHook,
+  NULL
+};
+
+/*
+ * Serial over USB driver configuration.
+ */
+const SerialUSBConfig serusbcfg = {
+  &USBD1,
+  USBD1_DATA_REQUEST_EP,
+  USBD1_DATA_AVAILABLE_EP,
+  USBD1_INTERRUPT_REQUEST_EP
+};

--- a/Avionics.Firmware/usbcfg.h
+++ b/Avionics.Firmware/usbcfg.h
@@ -1,0 +1,25 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef _USBCFG_H_
+#define _USBCFG_H_
+
+extern const USBConfig usbcfg;
+extern SerialUSBConfig serusbcfg;
+
+#endif  /* _USBCFG_H_ */
+
+/** @} */


### PR DESCRIPTION
Adds a stub USB serial console for the board. The most important commit is a12036d which adds a configuration option to `board.h` which is required to actually make USB work on our board. The other commits add a simple USB serial console based on the ChibiOS example code.

There are no commands beyond help, info, systime and exit now but one can actually connect to the board and ask it things over USB.
